### PR TITLE
CI enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ matrix:
       sudo: required
       dist: trusty
       services: docker
-      install: docker pull ubuntu:18.04
-      script: docker run -v $(pwd):/liftinstall ubuntu:18.04 /bin/bash -ex /liftinstall/.travis/build.sh
+      install: docker pull rust:1
+      script: docker run -v $(pwd):/liftinstall rust:1 /bin/bash -ex /liftinstall/.travis/build.sh
 
     - os: osx
       language: rust

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
-os: linux
-dist: trusty
-sudo: required
-services:
-  - docker
+matrix:
+  include:
+    - os: linux
+      language: cpp
+      sudo: required
+      dist: trusty
+      services: docker
+      install: docker pull ubuntu:18.04
+      script: docker run -v $(pwd):/liftinstall ubuntu:18.04 /bin/bash -ex /liftinstall/.travis/build.sh
 
-install:
- - docker pull ubuntu:18.04
+    - os: osx
+      language: rust
+      osx_image: xcode10
+      script: cargo build
 
-script:
- - docker run -v $(pwd):/liftinstall ubuntu:18.04 /bin/bash -ex /liftinstall/.travis/build.sh
+    - os: windows
+      language: rust
+      script: cargo build

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -4,7 +4,4 @@ cd /liftinstall || exit 1
 apt-get update
 apt-get install -y libwebkit2gtk-4.0-dev libssl-dev
 
-curl https://build.travis-ci.org/files/rustup-init.sh -sSf | sh -s -- -y
-export PATH=~/.cargo/bin:$PATH
-
 cargo build

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-cd /liftinstall
+cd /liftinstall || exit 1
 
-apt update
-apt install -y libwebkit2gtk-4.0-dev libssl-dev
+apt-get update
+apt-get install -y libwebkit2gtk-4.0-dev libssl-dev
 
-curl https://sh.rustup.rs -sSf | sh -s -- -y
+curl https://build.travis-ci.org/files/rustup-init.sh -sSf | sh -s -- -y
 export PATH=~/.cargo/bin:$PATH
 
 cargo build

--- a/bootstrap.macos.toml
+++ b/bootstrap.macos.toml
@@ -1,0 +1,3 @@
+# fake configuration for CI purpose only
+name = "yuzu"
+target_url = "https://raw.githubusercontent.com/j-selby/test-installer/master/config.linux.v2.toml"


### PR DESCRIPTION
This PR adds two additional operating systems for more references. The Linux Docker container has been changed to use official Rust Docker image.

Side-effect: This will prolong the CI runtime for each commits as Windows CI will take much time extracting Rust components (especially `rust-doc`).

Side-note: I have observed Travis CI is becoming somewhat unstable these days, if you want to migrate to other CI platforms like Circle CI or Azure Pipelines, I can help too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/j-selby/liftinstall/10)
<!-- Reviewable:end -->
