### PR TITLE
UI: Minor UI tweaks

### DIFF
--- a/ui/mock-server.js
+++ b/ui/mock-server.js
@@ -17,31 +17,7 @@ function progressSimulation (res) {
   }, 1500)
 }
 
-app.get('/api/attrs', (req, res) => {
-  res.send(
-    `var base_attributes = {"name":"yuzu","target_url":"https://raw.githubusercontent.com/j-selby/test-installer/master/config.linux.v2.toml"};`
-  )
-})
-
-app.get('/api/dark-mode', (req, res) => {
-  res.json(false)
-})
-
-app.get('/api/installation-status', (req, res) => {
-  res.json({
-    database: { packages: [], shortcuts: [] },
-    install_path: null,
-    preexisting_install: false,
-    is_launcher: false,
-    launcher_path: null
-  })
-})
-
-app.get('/api/default-path', (req, res) => {
-  res.json({ path: '/tmp/test/' })
-})
-
-app.get('/api/config', (req, res) => {
+function returnConfig (res) {
   res.json({
     installing_message:
       'Test Banner <strong>Bold</strong>&nbsp;<pre>Code block</pre>&nbsp;<i>Italic</i>&nbsp;<del>Strike</del>',
@@ -73,6 +49,36 @@ app.get('/api/config', (req, res) => {
     ],
     hide_advanced: false
   })
+}
+
+app.get('/api/attrs', (req, res) => {
+  res.send(
+    `var base_attributes = {"name":"yuzu","target_url":"https://raw.githubusercontent.com/j-selby/test-installer/master/config.linux.v2.toml"};`
+  )
+})
+
+app.get('/api/dark-mode', (req, res) => {
+  res.json(false)
+})
+
+app.get('/api/installation-status', (req, res) => {
+  res.json({
+    database: { packages: [], shortcuts: [] },
+    install_path: null,
+    preexisting_install: false,
+    is_launcher: false,
+    launcher_path: null
+  })
+})
+
+app.get('/api/default-path', (req, res) => {
+  res.json({ path: '/tmp/test/' })
+})
+
+app.get('/api/config', (req, res) => {
+  setTimeout(() => {
+    returnConfig(res)
+  }, 3000)
 })
 
 app.post('/api/start-install', (req, res) => {

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -2,9 +2,11 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import { ajax, stream_ajax } from './helpers'
+import Buefy from 'buefy'
 import 'buefy/dist/buefy.css'
 
 Vue.config.productionTip = false
+Vue.use(Buefy)
 
 // Borrowed from http://tobyho.com/2012/07/27/taking-over-console-log/
 function intercept (method) {

--- a/ui/src/views/DownloadConfig.vue
+++ b/ui/src/views/DownloadConfig.vue
@@ -3,7 +3,7 @@
             <h4 class="subtitle">Downloading config...</h4>
 
             <br />
-            <progress class="progress is-info is-medium" value="0" max="100">
+            <progress class="progress is-info is-medium" max="100">
                 0%
             </progress>
     </div>

--- a/ui/src/views/ErrorView.vue
+++ b/ui/src/views/ErrorView.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="column has-padding">
-    <b-message title="An error occurred" type="is-danger" :closable="false">{{ msg }}</b-message>
+    <b-message title="An error occurred" type="is-danger" :closable="false">
+      <span id="error_msg">{{ msg }}</span>
+    </b-message>
     <div class="field is-grouped is-right-floating is-bottom-floating">
       <p class="control">
         <a class="button is-primary is-medium" v-if="remaining" v-on:click="go_back">Back</a>
@@ -17,6 +19,14 @@
   white-space: -pre-wrap; /* Opera 4-6 */
   white-space: -o-pre-wrap; /* Opera 7 */
   word-wrap: break-word; /* Internet Explorer 5.5+ */
+}
+
+#error_msg {
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+    cursor: text;
 }
 </style>
 

--- a/ui/src/views/ErrorView.vue
+++ b/ui/src/views/ErrorView.vue
@@ -1,25 +1,22 @@
 <template>
-    <div class="column has-padding">
-            <h4 class="subtitle">An error occurred:</h4>
-
-            <pre class="pre-wrap">{{ msg }}</pre>
-
-            <div class="field is-grouped is-right-floating is-bottom-floating">
-                <p class="control">
-                    <a class="button is-primary is-medium" v-if="remaining" v-on:click="go_back">Back</a>
-                </p>
-            </div>
+  <div class="column has-padding">
+    <b-message title="An error occurred" type="is-danger" :closable="false">{{ msg }}</b-message>
+    <div class="field is-grouped is-right-floating is-bottom-floating">
+      <p class="control">
+        <a class="button is-primary is-medium" v-if="remaining" v-on:click="go_back">Back</a>
+      </p>
     </div>
+  </div>
 </template>
 
 <style>
 .pre-wrap {
   /* https://css-tricks.com/snippets/css/make-pre-text-wrap/ */
-  white-space: pre-wrap;       /* css-3 */
-  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-  white-space: -pre-wrap;      /* Opera 4-6 */
-  white-space: -o-pre-wrap;    /* Opera 7 */
-  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  white-space: pre-wrap; /* css-3 */
+  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+  white-space: -pre-wrap; /* Opera 4-6 */
+  white-space: -o-pre-wrap; /* Opera 7 */
+  word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 </style>
 

--- a/ui/src/views/SelectPackages.vue
+++ b/ui/src/views/SelectPackages.vue
@@ -8,8 +8,9 @@
                     <div class="tile is-child">
                         <div class="box clickable-box" v-on:click.capture.stop="Lpackage.default = !Lpackage.default">
                             <label class="checkbox">
-                                <input type="checkbox" v-model="Lpackage.default" />
-                                {{ Lpackage.name }}
+                                <b-checkbox v-model="Lpackage.default">
+                                  {{ Lpackage.name }}
+                                </b-checkbox>
                                 <span v-if="Lpackage.installed"><i>(installed)</i></span>
                             </label>
                             <p>


### PR DESCRIPTION
This PR adjusted certain UI elements:

1. Now, an indetermined progress bar will be shown when downloading the configuration file (so the user will know the program does not freeze):
![image](https://user-images.githubusercontent.com/6829345/60386189-9d030880-9ac4-11e9-9771-465975a085b1.png)

2. The checkbox is now using the `Bluma` styled one:
![image](https://user-images.githubusercontent.com/6829345/60386224-f0755680-9ac4-11e9-9c69-74209dba6747.png)

3. The error page is now looking more dangerously (!):
![image](https://user-images.githubusercontent.com/6829345/60386236-20245e80-9ac5-11e9-88d1-afd6a817c4a3.png)


Contains commits from #16 so it is blocked by that PR (so the CI status will be more accurate for **this** PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/j-selby/liftinstall/17)
<!-- Reviewable:end -->
