### PR TITLE
Use the correct icon for the application shortcuts

### DIFF
--- a/src/native/interop.cpp
+++ b/src/native/interop.cpp
@@ -43,7 +43,8 @@ extern "C" int saveShortcut(
     const wchar_t *description,
     const wchar_t *path,
     const wchar_t *args,
-    const wchar_t *workingDir)
+    const wchar_t *workingDir,
+    const wchar_t *exePath)
 {
     char *errStr = NULL;
     HRESULT h;
@@ -82,6 +83,9 @@ extern "C" int saveShortcut(
         shellLink->SetDescription(description);
     if (path != NULL)
         shellLink->SetPath(path);
+    // default to using the first icon in the exe (usually correct)
+    if (exePath != NULL)
+        shellLink->SetIconLocation(exePath, 0);
     if (args != NULL)
         shellLink->SetArguments(args);
     if (workingDir != NULL)

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -39,6 +39,7 @@ mod natives {
             path: *const winapi::ctypes::wchar_t,
             args: *const winapi::ctypes::wchar_t,
             workingDir: *const winapi::ctypes::wchar_t,
+            exePath: *const winapi::ctypes::wchar_t,
         ) -> ::std::os::raw::c_int;
 
         pub fn isDarkThemeActive() -> ::std::os::raw::c_uint;
@@ -59,6 +60,7 @@ mod natives {
         target: &str,
         args: &str,
         working_dir: &str,
+        exe_path: &str,
     ) -> Result<String, String> {
         let source_file = format!(
             "{}\\Microsoft\\Windows\\Start Menu\\Programs\\{}.lnk",
@@ -78,6 +80,8 @@ mod natives {
             U16CString::from_str(args).log_expect("Error while converting to wchar_t");
         let native_working_dir =
             U16CString::from_str(working_dir).log_expect("Error while converting to wchar_t");
+        let native_exe_path =
+            U16CString::from_str(exe_path).log_expect("Error while converting to wchar_t");
 
         let shortcutResult = unsafe {
             saveShortcut(
@@ -86,6 +90,7 @@ mod natives {
                 native_target.as_ptr(),
                 native_args.as_ptr(),
                 native_working_dir.as_ptr(),
+                native_exe_path.as_ptr(),
             )
         };
 

--- a/src/tasks/install_global_shortcut.rs
+++ b/src/tasks/install_global_shortcut.rs
@@ -58,6 +58,7 @@ impl Task for InstallGlobalShortcutsTask {
             // TODO: Send by list
             "",
             &starting_dir,
+            "",
         )?;
 
         if !shortcut_file.is_empty() {

--- a/src/tasks/install_shortcuts.rs
+++ b/src/tasks/install_shortcuts.rs
@@ -83,6 +83,7 @@ impl Task for InstallShortcutsTask {
                 // TODO: Send by list
                 &format!("--launcher \"{}\"", exe_path),
                 &starting_dir,
+                exe_path,
             )?);
         }
 


### PR DESCRIPTION
This changes the shortcut creation a little bit to pass in the actual exe path to the cpp interop. this way in windows we can use IShellLink::SetIconLocation to point to the actual target's exe icon instead of the maintenance tool's